### PR TITLE
Add funding and support configuration; sponsorship templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+github: joe10832
+# Optional providers you can enable by replacing or adding values:
+# patreon: your-patreon-name
+# ko-fi: your-ko-fi-id
+# open_collective: your-open-collective-slug

--- a/.github/ISSUE_TEMPLATE/sponsorship_request.md
+++ b/.github/ISSUE_TEMPLATE/sponsorship_request.md
@@ -1,0 +1,13 @@
+---
+name: Sponsorship / commercial inquiry
+about: Use this template when you want to discuss sponsoring this project or hiring for paid work
+title: '[Sponsorship] '
+labels: sponsorship
+assignees: ''
+---
+
+Please describe:
+- Type of sponsorship or paid work you are proposing:
+- Budget / range:
+- Timeline:
+- Contact information:

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,11 @@
+# Support & Sponsorship
+
+Thanks for checking out this project!
+
+If you'd like to support development:
+- Sponsor this project on GitHub: https://github.com/sponsors/joe10832
+- For commercial or paid work inquiries, contact: <your-email-or-contact-method>
+
+Notes for repository owner (you):
+- To receive funds through GitHub Sponsors you must enable GitHub Sponsors on your account and configure your payout/payment details.
+- Adding .github/FUNDING.yml makes sponsor buttons appear in places GitHub shows funding options.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # .github-MunyayLLC-
 GitHub’s official command line tool
+
+Support development
+-------------------
+If you find this repo useful, you can support ongoing work:
+
+- Sponsor on GitHub: https://github.com/sponsors/joe10832
+- (Optional) Add other support links in .github/FUNDING.yml (Patreon, Ko-fi, Open Collective)
+
+Thank you for your support — every contribution helps keep development moving!


### PR DESCRIPTION
This pull request adds support and sponsorship information to the repository. It introduces new documentation to guide users on how to sponsor the project, provides a template for sponsorship or commercial inquiries, and updates the repository to display GitHub Sponsors options.

Support and sponsorship documentation:

* Added a new `SUPPORT.md` file with instructions for sponsoring the project and information for both users and the repository owner. (.github/SUPPORT.md)
* Updated the `README.md` to include a section on supporting development, with links and instructions for sponsorship. (README.md)

Sponsorship configuration and templates:

* Added a `FUNDING.yml` file to enable GitHub Sponsors and provide placeholders for other funding options. (.github/FUNDING.yml)
* Created a new issue template for sponsorship or commercial inquiries, making it easier for users to request paid work or sponsorships. (.github/ISSUE_TEMPLATE/sponsorship_request.md)